### PR TITLE
Add continued fraction representation of a rational.

### DIFF
--- a/test/ratio/float_conversion_test.exs
+++ b/test/ratio/float_conversion_test.exs
@@ -4,7 +4,7 @@ defmodule Ratio.FloatConversionTest do
   # use Ratio coerces negative floats to Ratios, so the below test needs to be run outside the Ratio.FloatConversion
   # module.
   test "float conversion for negative numbers" do
-    assert %Ratio{numerator: -2_476_979_795_053_773, denominator: 2_251_799_813_685_248} ==
+    assert %Ratio{numerator: -2_476_979_795_053_773, denominator: 2_251_799_813_685_248, continued_fraction_representation: [-1, 9, -1, 112589990684261, -2]} ==
              Ratio.FloatConversion.float_to_rational(-1.1)
   end
 end

--- a/test/ratio/float_conversion_test.exs
+++ b/test/ratio/float_conversion_test.exs
@@ -4,7 +4,11 @@ defmodule Ratio.FloatConversionTest do
   # use Ratio coerces negative floats to Ratios, so the below test needs to be run outside the Ratio.FloatConversion
   # module.
   test "float conversion for negative numbers" do
-    assert %Ratio{numerator: -2_476_979_795_053_773, denominator: 2_251_799_813_685_248, continued_fraction_representation: [-1, 9, -1, 112589990684261, -2]} ==
+    assert %Ratio{
+             numerator: -2_476_979_795_053_773,
+             denominator: 2_251_799_813_685_248,
+             continued_fraction_representation: [-1, -1, 9, -1, 112_589_990_684_261, -2]
+           } ==
              Ratio.FloatConversion.float_to_rational(-1.1)
   end
 end

--- a/test/ratio_test.exs
+++ b/test/ratio_test.exs
@@ -8,7 +8,7 @@ defmodule RatioTest do
   doctest Ratio.FloatConversion
 
   test "definition of <|> operator" do
-    assert 1 <|> 3 == %Ratio{numerator: 1, denominator: 3}
+    assert 1 <|> 3 == %Ratio{numerator: 1, denominator: 3, continued_fraction_representation: [0, -3]}
   end
 
   test "reject _ <|> 0" do

--- a/test/ratio_test.exs
+++ b/test/ratio_test.exs
@@ -8,7 +8,11 @@ defmodule RatioTest do
   doctest Ratio.FloatConversion
 
   test "definition of <|> operator" do
-    assert 1 <|> 3 == %Ratio{numerator: 1, denominator: 3, continued_fraction_representation: [0, -3]}
+    assert 1 <|> 3 == %Ratio{
+             numerator: 1,
+             denominator: 3,
+             continued_fraction_representation: [1, 0, -3]
+           }
   end
 
   test "reject _ <|> 0" do
@@ -45,6 +49,18 @@ defmodule RatioTest do
 
     assert Ratio.equal?(1 <|> 3, 1 <|> 3)
     refute Ratio.equal?(1 <|> 3, 1 <|> 4)
+  end
+
+  test "implicit comparison operators" do
+    assert 1 <|> 2 > 1 <|> 3
+    assert -1 <|> 2 < 1 <|> 3
+    assert 1 <|> 2 > -1 <|> 3
+    assert -1 <|> 2 < -1 <|> 3
+
+    assert Ratio.new(-2.3) > Ratio.new(-5.1)
+    assert Ratio.new(2.3) > Ratio.new(-5.1)
+    assert Ratio.new(-2.3) < Ratio.new(5.1)
+    assert Ratio.new(2.3) < Ratio.new(5.1)
   end
 
   test "small number precision" do


### PR DESCRIPTION
This PR introduces a continued fraction representation of the rational, as described here: https://membraneframework.atlassian.net/wiki/spaces/MEMBRANEFR/pages/16056356/Timestamps#Experimental-approaches

With such a feature enabled, the two Ratio structs could be compared without the `use Ratio` clause on top of the module. 